### PR TITLE
Allow trailing whitespace to be insignificant when comparing YAML-based approvals

### DIFF
--- a/lib/approvals/verifier.rb
+++ b/lib/approvals/verifier.rb
@@ -1,9 +1,11 @@
 require 'approvals/verifiers/json_verifier'
+require 'approvals/verifiers/yaml_verifier'
 
 module Approvals
   module Verifier
     REGISTRY = {
       json: Verifiers::JsonVerifier,
+      yaml: Verifiers::YamlVerifier,
     }
 
     class << self

--- a/lib/approvals/verifiers/yaml_verifier.rb
+++ b/lib/approvals/verifiers/yaml_verifier.rb
@@ -1,0 +1,30 @@
+module Approvals
+  module Verifiers
+    class YamlVerifier
+      def initialize(received_path, approved_path)
+        self.received_path = received_path
+        self.approved_path = approved_path
+      end
+
+      def verify
+        approved == received
+      end
+
+      private
+
+      attr_accessor :approved_path, :received_path
+
+      def approved
+        strip_trailing_whitespace(File.read(approved_path))
+      end
+
+      def received
+        strip_trailing_whitespace(File.read(received_path))
+      end
+
+      def strip_trailing_whitespace(content)
+        content.to_s.split("\n").map(&:rstrip).join
+      end
+    end
+  end
+end

--- a/lib/approvals/writer.rb
+++ b/lib/approvals/writer.rb
@@ -5,6 +5,7 @@ require 'approvals/writers/html_writer'
 require 'approvals/writers/xml_writer'
 require 'approvals/writers/json_writer'
 require 'approvals/writers/binary_writer'
+require 'approvals/writers/yaml_writer'
 
 module Approvals
   module Writer
@@ -17,6 +18,7 @@ module Approvals
       hash: Writers::HashWriter.new,
       array: Writers::ArrayWriter.new,
       txt: Writers::TextWriter.new,
+      yaml: Writers::YamlWriter.new,
     }
 
 

--- a/lib/approvals/writers/yaml_writer.rb
+++ b/lib/approvals/writers/yaml_writer.rb
@@ -1,0 +1,13 @@
+module Approvals
+  module Writers
+    class YamlWriter < TextWriter
+      def extension
+        'yaml'
+      end
+
+      def format(data)
+        data.to_yaml
+      end
+    end
+  end
+end

--- a/spec/fixtures/yaml/approved.yaml
+++ b/spec/fixtures/yaml/approved.yaml
@@ -1,0 +1,5 @@
+---
+key:
+  nested_key:
+    value: 1
+    missing: 

--- a/spec/fixtures/yaml/different_content.yaml
+++ b/spec/fixtures/yaml/different_content.yaml
@@ -1,0 +1,5 @@
+---
+key:
+  nested_key:
+    value: 2
+    missing: 

--- a/spec/fixtures/yaml/received.yaml
+++ b/spec/fixtures/yaml/received.yaml
@@ -1,0 +1,5 @@
+---
+key:
+  nested_key:
+    value: 1
+    missing:

--- a/spec/verifiers/yaml_verifier_spec.rb
+++ b/spec/verifiers/yaml_verifier_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe Approvals::Verifiers::YamlVerifier do
+  subject(:instance) do
+    described_class.new(received_path, approved_path)
+  end
+
+  context "with same yaml content but different formatting" do
+    let(:received_path) do
+      "./spec/fixtures/yaml/received.yaml"
+    end
+    let(:approved_path) do
+      "./spec/fixtures/yaml/approved.yaml"
+    end
+
+    it "passes verification" do
+      expect(instance.verify).to be(true)
+    end
+  end
+
+  context "with different yaml content" do
+    let(:received_path) do
+      "./spec/fixtures/yaml/different_content.yaml"
+    end
+    let(:approved_path) do
+      "./spec/fixtures/yaml/approved.yaml"
+    end
+
+    it "does not pass verification" do
+      expect(instance.verify).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
The [0.2.5 release of libyaml](https://github.com/yaml/libyaml/releases/tag/0.2.5) altered the handling of nil scalar values such that a space would no longer be emitted—this breaks the approvals process when files are written using an earlier version of libyaml (e.g. on Ubuntu) and then compared on any other platform where libyaml >= 0.2.5 is used.

This PR introduces a YAML approval format type, which allows approval files which differ only by trailing whitespace to be considered equal.